### PR TITLE
Support multiple ioctl calls

### DIFF
--- a/fiemap.c
+++ b/fiemap.c
@@ -47,62 +47,125 @@ void syntax(char **argv)
 
 struct fiemap *read_fiemap(int fd)
 {
-	struct fiemap *fiemap, *tmp;
+	struct fiemap *fiemap = NULL;
+	struct fiemap *result_fiemap = NULL;
+	struct fiemap *fm_tmp; /* need to store pointer on realloc */
 	int extents_size;
 	struct stat statinfo;
-	__u64 fiemap_length;
+	__u32 result_extents = 0;
+	__u64 fiemap_start = 0, fiemap_length;
 
-	if (fstat(fd, &statinfo)) {
+	if (fstat(fd, &statinfo) != 0) {
 		fprintf(stderr, "Can't determine file size [%d] (%s)\n",
 				errno, strerror(errno));
 		return NULL;
 	}
 	fiemap_length = statinfo.st_size;
 
-	if ((fiemap = (struct fiemap*)malloc(sizeof(struct fiemap))) == NULL) {
+	fiemap = malloc(sizeof(struct fiemap));
+	if (fiemap == NULL) {
 		fprintf(stderr, "Out of memory allocating fiemap\n");
 		return NULL;
 	}
-	memset(fiemap, 0, sizeof(struct fiemap));
 
-	fiemap->fm_start = 0;
-	fiemap->fm_length = fiemap_length;
-	fiemap->fm_flags = 0;
-	fiemap->fm_extent_count = 0;
-	fiemap->fm_mapped_extents = 0;
-
-	/* Find out how many extents there are */
-	if (ioctl(fd, FS_IOC_FIEMAP, fiemap) < 0) {
-		fprintf(stderr, "fiemap ioctl() failed\n");
-		free(fiemap);
-		return NULL;
-	}
-
-	/* Read in the extents */
-	extents_size = sizeof(struct fiemap_extent) *
-                              (fiemap->fm_mapped_extents);
-
-	/* Resize fiemap to allow us to read in the extents */
-	tmp = (struct fiemap *)realloc(fiemap,sizeof(struct fiemap) +
-                                       extents_size);
-	if (!tmp) {
+	result_fiemap = malloc(sizeof(struct fiemap));
+	if (result_fiemap == NULL) {
 		fprintf(stderr, "Out of memory allocating fiemap\n");
-		free(fiemap);
-		return NULL;
-	}
-	fiemap = tmp;
-
-	memset(fiemap->fm_extents, 0, extents_size);
-	fiemap->fm_extent_count = fiemap->fm_mapped_extents;
-	fiemap->fm_mapped_extents = 0;
-
-	if (ioctl(fd, FS_IOC_FIEMAP, fiemap) < 0) {
-		fprintf(stderr, "fiemap ioctl() failed\n");
-		free(fiemap);
-		return NULL;
+		goto fail_cleanup;
 	}
 
-	return fiemap;
+	/*  XFS filesystem has incorrect implementation of fiemap ioctl and
+	 *  returns extents for only one block-group at a time, so we need
+	 *  to handle it manually, starting the next fiemap call from the end
+	 *  of the last extent
+	 */
+	while (fiemap_start < fiemap_length) {
+		fprintf(stderr, "DEBUG: %llu -> %llu\n", fiemap_start, fiemap_length);
+
+		memset(fiemap, 0, sizeof(struct fiemap));
+
+		fiemap->fm_start = fiemap_start;
+		fiemap->fm_length = fiemap_length;
+		fiemap->fm_flags = FIEMAP_FLAG_SYNC;
+
+		/* Find out how many extents there are */
+		if (ioctl(fd, FS_IOC_FIEMAP, fiemap) < 0) {
+			fprintf(stderr, "fiemap ioctl() failed\n");
+			goto fail_cleanup;
+		}
+
+		/* Nothing to process */
+		if (fiemap->fm_mapped_extents == 0)
+			break;
+
+		/* Result fiemap have to hold all the extents for the hole file
+		 */
+
+		/* Read in the extents */
+		extents_size = sizeof(struct fiemap_extent) *
+		                      (fiemap->fm_mapped_extents);
+
+		/* Resize fiemap to allow us to read in the extents */
+		fm_tmp = realloc(fiemap,
+				 sizeof(struct fiemap) + extents_size);
+		if (!fm_tmp) {
+			fprintf(stderr, "Out of memory allocating fiemap\n");
+			goto fail_cleanup;
+		}
+		fiemap = fm_tmp;
+
+		memset(fiemap->fm_extents, 0, extents_size);
+		fiemap->fm_extent_count = fiemap->fm_mapped_extents;
+		fiemap->fm_mapped_extents = 0;
+
+		if (ioctl(fd, FS_IOC_FIEMAP, fiemap) < 0) {
+			fprintf(stderr, "fiemap ioctl() failed\n");
+			goto fail_cleanup;
+		}
+
+		extents_size = sizeof(struct fiemap_extent) *
+		                      (result_extents +
+				       fiemap->fm_mapped_extents);
+
+		/* Resize result_fiemap to allow us to read in the extents */
+		fm_tmp = realloc(result_fiemap,
+				 sizeof(struct fiemap) + extents_size);
+		if (!fm_tmp) {
+			fprintf(stderr, "Out of memory allocating fiemap\n");
+			goto fail_cleanup;
+		}
+		result_fiemap = fm_tmp;
+
+		memcpy(result_fiemap->fm_extents + result_extents,
+		       fiemap->fm_extents,
+		       sizeof(struct fiemap_extent) *
+		       fiemap->fm_mapped_extents);
+
+		result_extents += fiemap->fm_mapped_extents;
+
+		fiemap_start = fiemap->fm_extents[fiemap->fm_mapped_extents -
+						  1].fe_logical +
+			       fiemap->fm_extents[fiemap->fm_mapped_extents -
+						  1].fe_length;
+
+		if (fiemap->fm_extents[fiemap->fm_mapped_extents - 1].fe_flags &
+		    FIEMAP_EXTENT_LAST)
+			break;
+	}
+
+	result_fiemap->fm_mapped_extents = result_extents;
+	free(fiemap);
+
+	return result_fiemap;
+
+fail_cleanup:
+	if (result_fiemap)
+		free(result_fiemap);
+
+	if (fiemap)
+		free(fiemap);
+
+	return NULL;
 }
 
 void dump_fiemap(struct fiemap *fiemap, char *filename)


### PR DESCRIPTION
Old version of XFS returns only extents of one extent group per ioctl call.
If the file spreads to several extent groups, we have to make mutiple ioctl calls to get full fiemap.
